### PR TITLE
Fix authentication docs slug

### DIFF
--- a/config/docs.ts
+++ b/config/docs.ts
@@ -29,8 +29,8 @@ export const docsConfig: DocsConfig = {
       title: "Configuration",
       items: [
         {
-          title: "Authentification",
-          href: "/docs/configuration/authentification",
+          title: "Authentication",
+          href: "/docs/configuration/authentication",
         },
         {
           title: "Blog",

--- a/content/docs/configuration/authentication.mdx
+++ b/content/docs/configuration/authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: Authentification
-description: How to config the authentification.
+title: Authentication
+description: How to config the authentication.
 ---
 
 <Callout type="note" twClass="mt-0">


### PR DESCRIPTION
## Summary
- rename `authentification` doc file to English `authentication`
- update front matter in doc
- fix sidebar docs config to use new slug

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68418ca06788832fa93a7268973eb565