### PR TITLE
Add dashboard workout pages

### DIFF
--- a/app/(protected)/dashboard/workouts/[id]/edit/loading.tsx
+++ b/app/(protected)/dashboard/workouts/[id]/edit/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardHeader } from "@/components/dashboard/header";
+
+export default function EditWorkoutLoading() {
+  return (
+    <>
+      <DashboardHeader
+        heading="Edit Workout Session"
+        text="Edit your workout session."
+      />
+      <Skeleton className="h-[500px] w-full rounded-lg" />
+    </>
+  );
+}

--- a/app/(protected)/dashboard/workouts/[id]/edit/page.tsx
+++ b/app/(protected)/dashboard/workouts/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+import { constructMetadata } from "@/lib/utils";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { WorkoutSessionForm } from "@/components/forms/workout-session-form";
+
+export const metadata = constructMetadata({
+  title: "Edit Workout – SaaS Starter",
+  description: "Edit your workout session.",
+});
+
+interface EditWorkoutPageProps {
+  params: { id: string };
+}
+
+export default function EditWorkoutPage({ params }: EditWorkoutPageProps) {
+  return (
+    <>
+      <DashboardHeader
+        heading="Edit Workout Session"
+        text="Edit your workout session."
+      />
+      <WorkoutSessionForm />
+    </>
+  );
+}

--- a/app/(protected)/dashboard/workouts/loading.tsx
+++ b/app/(protected)/dashboard/workouts/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardHeader } from "@/components/dashboard/header";
+
+export default function WorkoutsLoading() {
+  return (
+    <>
+      <DashboardHeader
+        heading="Workouts"
+        text="Create and manage your workout sessions."
+      />
+      <Skeleton className="size-full rounded-lg" />
+    </>
+  );
+}

--- a/app/(protected)/dashboard/workouts/new/loading.tsx
+++ b/app/(protected)/dashboard/workouts/new/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardHeader } from "@/components/dashboard/header";
+
+export default function NewWorkoutLoading() {
+  return (
+    <>
+      <DashboardHeader
+        heading="New Workout Session"
+        text="Create a new workout session."
+      />
+      <Skeleton className="h-[500px] w-full rounded-lg" />
+    </>
+  );
+}

--- a/app/(protected)/dashboard/workouts/new/page.tsx
+++ b/app/(protected)/dashboard/workouts/new/page.tsx
@@ -1,0 +1,20 @@
+import { constructMetadata } from "@/lib/utils";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { WorkoutSessionForm } from "@/components/forms/workout-session-form";
+
+export const metadata = constructMetadata({
+  title: "New Workout – SaaS Starter",
+  description: "Create a new workout session.",
+});
+
+export default function NewWorkoutPage() {
+  return (
+    <>
+      <DashboardHeader
+        heading="New Workout Session"
+        text="Create a new workout session."
+      />
+      <WorkoutSessionForm />
+    </>
+  );
+}

--- a/app/(protected)/dashboard/workouts/page.tsx
+++ b/app/(protected)/dashboard/workouts/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+import { constructMetadata } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { DashboardHeader } from "@/components/dashboard/header";
+import { EmptyPlaceholder } from "@/components/shared/empty-placeholder";
+
+export const metadata = constructMetadata({
+  title: "Workouts – SaaS Starter",
+  description: "Create and manage your workout sessions.",
+});
+
+export default function WorkoutsPage() {
+  return (
+    <>
+      <DashboardHeader
+        heading="Workouts"
+        text="Create and manage your workout sessions."
+      >
+        <Button asChild>
+          <Link href="/dashboard/workouts/new">New Session</Link>
+        </Button>
+      </DashboardHeader>
+      <EmptyPlaceholder>
+        <EmptyPlaceholder.Icon name="post" />
+        <EmptyPlaceholder.Title>No sessions created</EmptyPlaceholder.Title>
+        <EmptyPlaceholder.Description>
+          You don&apos;t have any workout sessions yet.
+        </EmptyPlaceholder.Description>
+        <Button asChild variant="outline">
+          <Link href="/dashboard/workouts/new">Create Session</Link>
+        </Button>
+      </EmptyPlaceholder>
+    </>
+  );
+}

--- a/components/forms/workout-session-form.tsx
+++ b/components/forms/workout-session-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useTransition } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { toast } from "sonner";
+
+import { workoutSessionSchema } from "@/lib/validations/workout";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Icons } from "@/components/shared/icons";
+
+export type WorkoutSessionFormData = z.infer<typeof workoutSessionSchema>;
+
+interface WorkoutSessionFormProps {
+  defaultValues?: WorkoutSessionFormData;
+  onSubmit?: (data: WorkoutSessionFormData) => Promise<void> | void;
+}
+
+export function WorkoutSessionForm({
+  defaultValues,
+  onSubmit,
+}: WorkoutSessionFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<WorkoutSessionFormData>({
+    resolver: zodResolver(workoutSessionSchema),
+    defaultValues: defaultValues ?? {
+      title: "",
+      description: "",
+      date: "",
+      duration: 30,
+    },
+  });
+
+  function submit(data: WorkoutSessionFormData) {
+    startTransition(async () => {
+      if (onSubmit) {
+        await onSubmit(data);
+      }
+      toast.success(defaultValues ? "Session updated" : "Session created");
+      reset();
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit(submit)} className="space-y-4">
+      <div className="grid gap-2">
+        <Label htmlFor="title">Title</Label>
+        <Input id="title" {...register("title")}/>
+        {errors.title && (
+          <p className="px-1 text-sm text-red-600">{errors.title.message}</p>
+        )}
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="date">Date</Label>
+        <Input id="date" type="date" {...register("date")} />
+        {errors.date && (
+          <p className="px-1 text-sm text-red-600">{errors.date.message}</p>
+        )}
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="duration">Duration (min)</Label>
+        <Input id="duration" type="number" {...register("duration", { valueAsNumber: true })} />
+        {errors.duration && (
+          <p className="px-1 text-sm text-red-600">{errors.duration.message}</p>
+        )}
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="description">Description</Label>
+        <Textarea id="description" rows={3} {...register("description")} />
+        {errors.description && (
+          <p className="px-1 text-sm text-red-600">{errors.description.message}</p>
+        )}
+      </div>
+      <Button type="submit" disabled={isPending}>
+        {isPending && <Icons.spinner className="mr-2 size-4 animate-spin" />}
+        {defaultValues ? "Save Changes" : "Create Session"}
+      </Button>
+    </form>
+  );
+}

--- a/config/dashboard.ts
+++ b/config/dashboard.ts
@@ -20,6 +20,7 @@ export const sidebarLinks: SidebarNavItem[] = [
         authorizeOnly: UserRole.USER,
       },
       { href: "/dashboard/charts", icon: "lineChart", title: "Charts" },
+      { href: "/dashboard/workouts", icon: "post", title: "Workouts" },
       {
         href: "/admin/orders",
         icon: "package",

--- a/lib/validations/workout.ts
+++ b/lib/validations/workout.ts
@@ -1,0 +1,8 @@
+import * as z from "zod";
+
+export const workoutSessionSchema = z.object({
+  title: z.string().min(3).max(50),
+  date: z.string(),
+  duration: z.coerce.number().min(1).max(360),
+  description: z.string().max(200).optional(),
+});


### PR DESCRIPTION
## Summary
- configure dashboard to include Workouts link
- validate workout sessions with a new zod schema
- add `WorkoutSessionForm` component
- add pages for listing, creating and editing workouts

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68418b9eefbc832fb16db16771d622ac