### PR TITLE
Fix Resend API key line

### DIFF
--- a/content/docs/configuration/email.mdx
+++ b/content/docs/configuration/email.mdx
@@ -30,7 +30,7 @@ If don't have an account on Resend, just follow their steps after signup [here](
 
 ### Create an API key
 
-After signin on Resend, he propurse you to create your first API key.
+After signing in on Resend, it proposes you to create your first API key.
 
 Copy/paste in your `.env` file.
 


### PR DESCRIPTION
## Summary
- fix grammar in the Resend API key setup instructions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68418f31c560832f9691fed0235f8510