### PR TITLE
Add default env vars

### DIFF
--- a/env.mjs
+++ b/env.mjs
@@ -5,23 +5,38 @@ export const env = createEnv({
   server: {
     // This is optional because it's only used in development.
     // See https://next-auth.js.org/deployment.
-    NEXTAUTH_URL: z.string().url().optional(),
-    AUTH_SECRET: z.string().min(1),
-    GOOGLE_CLIENT_ID: z.string().min(1),
-    GOOGLE_CLIENT_SECRET: z.string().min(1),
-    GITHUB_OAUTH_TOKEN: z.string().min(1),
-    DATABASE_URL: z.string().min(1),
-    RESEND_API_KEY: z.string().min(1),
-    EMAIL_FROM: z.string().min(1),
-    STRIPE_API_KEY: z.string().min(1),
-    STRIPE_WEBHOOK_SECRET: z.string().min(1),
+    NEXTAUTH_URL: z
+      .string()
+      .url()
+      .optional()
+      .default("http://localhost:3000/api/auth"),
+    AUTH_SECRET: z.string().min(1).default("test"),
+    GOOGLE_CLIENT_ID: z.string().min(1).default("test"),
+    GOOGLE_CLIENT_SECRET: z.string().min(1).default("test"),
+    GITHUB_OAUTH_TOKEN: z.string().optional(),
+    DATABASE_URL: z
+      .string()
+      .min(1)
+      .default(
+        "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable",
+      ),
+    RESEND_API_KEY: z.string().min(1).default("test"),
+    EMAIL_FROM: z.string().min(1).default("test@example.com"),
+    STRIPE_API_KEY: z.string().min(1).default("test"),
+    STRIPE_WEBHOOK_SECRET: z.string().min(1).default("test"),
   },
   client: {
-    NEXT_PUBLIC_APP_URL: z.string().min(1),
-    NEXT_PUBLIC_STRIPE_PRO_MONTHLY_PLAN_ID: z.string().min(1),
-    NEXT_PUBLIC_STRIPE_PRO_YEARLY_PLAN_ID: z.string().min(1),
-    NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PLAN_ID: z.string().min(1),
-    NEXT_PUBLIC_STRIPE_BUSINESS_YEARLY_PLAN_ID: z.string().min(1),
+    NEXT_PUBLIC_APP_URL: z.string().min(1).default("http://localhost:3000"),
+    NEXT_PUBLIC_STRIPE_PRO_MONTHLY_PLAN_ID: z.string().min(1).default("test"),
+    NEXT_PUBLIC_STRIPE_PRO_YEARLY_PLAN_ID: z.string().min(1).default("test"),
+    NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PLAN_ID: z
+      .string()
+      .min(1)
+      .default("test"),
+    NEXT_PUBLIC_STRIPE_BUSINESS_YEARLY_PLAN_ID: z
+      .string()
+      .min(1)
+      .default("test"),
   },
   runtimeEnv: {
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,


### PR DESCRIPTION
## Summary
- supply defaults for env vars so the app can start without config

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841938d0270832f97e3269963d684c6